### PR TITLE
specify css exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,15 @@
   "style": "./dist/handy-scroll.css",
   "types": "./dist/handy-scroll.d.ts",
   "exports": {
-    "types": "./dist/handy-scroll.d.ts",
-    "import": "./src/handy-scroll.js",
-    "require": "./dist/handy-scroll.js"
+    ".": {
+      "types": "./dist/handy-scroll.d.ts",
+      "import": "./src/handy-scroll.js",
+      "require": "./dist/handy-scroll.js"
+    },
+    "./dist/*.css": {
+      "import": "./dist/*.css",
+      "require": "./dist/*.css"
+    }
   },
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
       "import": "./src/handy-scroll.js",
       "require": "./dist/handy-scroll.js"
     },
-    "./dist/*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css"
-    }
+    "./dist/*.css": "./dist/*.css"
   },
   "type": "module",
   "files": [


### PR DESCRIPTION
Currently only the JS is specified in the `exports` within package.json. When `exports` field is present, it means anything not explicitly listed inside is not exposed. This means the css is not exposed. This results in this error message when using vite:

```
[commonjs--resolver] Missing "./dist/handy-scroll.css" specifier in "handy-scroll" package
error during build:
Error: Missing "./dist/handy-scroll.css" specifier in "handy-scroll" package
```

Per https://github.com/vitejs/vite/discussions/2657#discussioncomment-5856903, a separate export can be added to expose the css.

How I tested: I updated the `exports` package.json within my `node_modules/handy-scroll` where I was having this issue and this change resolved the issue.
