### PR TITLE
Apply CSS by adopting stylesheet rather than appending inline styles

### DIFF
--- a/dist/handy-scroll.mjs
+++ b/dist/handy-scroll.mjs
@@ -3,9 +3,10 @@ handy-scroll v2.0.3
 https://amphiluke.github.io/handy-scroll/
 (c) 2025 Amphiluke
 */
-const h = ':host{bottom:0;min-height:17px;overflow:auto;position:fixed}.strut{height:1px;overflow:hidden;pointer-events:none;&:before{content:" "}}:host,.strut{font-size:1px;line-height:0;margin:0;padding:0}:host(:state(latent)){bottom:110vh;.strut:before{content:"  "}}:host([viewport]:not([hidden])){display:block}:host([viewport]){position:sticky}:host([viewport]:state(latent)){position:fixed}';
+const o = ':host{bottom:0;min-height:17px;overflow:auto;position:fixed}.strut{height:1px;overflow:hidden;pointer-events:none;&:before{content:" "}}:host,.strut{font-size:1px;line-height:0;margin:0;padding:0}:host(:state(latent)){bottom:110vh;.strut:before{content:"  "}}:host([viewport]:not([hidden])){display:block}:host([viewport]){position:sticky}:host([viewport]:state(latent)){position:fixed}', h = new CSSStyleSheet();
+h.replaceSync(o);
 let n = (s) => `Attribute ‘${s}’ must reference a valid container ‘id’`;
-class o extends HTMLElement {
+class r extends HTMLElement {
   static get observedAttributes() {
     return ["owner", "viewport", "hidden"];
   }
@@ -37,8 +38,8 @@ class o extends HTMLElement {
   }
   constructor() {
     super();
-    let t = this.attachShadow({ mode: "open" }), e = document.createElement("style");
-    e.textContent = h, t.appendChild(e), this.#s = document.createElement("div"), this.#s.classList.add("strut"), t.appendChild(this.#s), this.#o = this.attachInternals();
+    let t = this.attachShadow({ mode: "open" });
+    t.adoptedStyleSheets = [h], this.#s = document.createElement("div"), this.#s.classList.add("strut"), t.appendChild(this.#s), this.#o = this.attachInternals();
   }
   connectedCallback() {
     this.#a(), this.#c(), this.#u(), this.#p(), this.update();
@@ -104,17 +105,17 @@ class o extends HTMLElement {
   #v() {
     let t = this.scrollWidth <= this.offsetWidth;
     if (!t) {
-      let e = this.#e.getBoundingClientRect(), i = this.#t === window ? window.innerHeight || document.documentElement.clientHeight : this.#t.getBoundingClientRect().bottom;
-      t = e.bottom <= i || e.top > i;
+      let i = this.#e.getBoundingClientRect(), e = this.#t === window ? window.innerHeight || document.documentElement.clientHeight : this.#t.getBoundingClientRect().bottom;
+      t = i.bottom <= e || i.top > e;
     }
     this.#h !== t && (this.#h = t);
   }
   update() {
-    let { clientWidth: t, scrollWidth: e } = this.#e, { style: i } = this;
-    i.width = `${t}px`, this.#t === window && (i.left = `${this.#e.getBoundingClientRect().left}px`), this.#s.style.width = `${e}px`, e > t && (i.height = `${this.offsetHeight - this.clientHeight + 1}px`), this.#d(), this.#v();
+    let { clientWidth: t, scrollWidth: i } = this.#e, { style: e } = this;
+    e.width = `${t}px`, this.#t === window && (e.left = `${this.#e.getBoundingClientRect().left}px`), this.#s.style.width = `${i}px`, i > t && (e.height = `${this.offsetHeight - this.clientHeight + 1}px`), this.#d(), this.#v();
   }
 }
-customElements.define("handy-scroll", o);
+customElements.define("handy-scroll", r);
 export {
-  o as default
+  r as default
 };

--- a/src/handy-scroll.mjs
+++ b/src/handy-scroll.mjs
@@ -1,5 +1,8 @@
 import css from "./handy-scroll.css?inline";
 
+const stylesheet = new CSSStyleSheet();
+stylesheet.replaceSync(css);
+
 let getAttributeErrorMessage = (attribute) => `Attribute ‘${attribute}’ must reference a valid container ‘id’`;
 
 class HandyScroll extends HTMLElement {
@@ -44,9 +47,7 @@ class HandyScroll extends HTMLElement {
     super();
     let shadowRoot = this.attachShadow({mode: "open"});
 
-    let style = document.createElement("style");
-    style.textContent = css;
-    shadowRoot.appendChild(style);
+    shadowRoot.adoptedStyleSheets = [stylesheet];
 
     this.#strut = document.createElement("div");
     this.#strut.classList.add("strut");


### PR DESCRIPTION
Addresses issue #27 by loading the CSS into a stylesheet and adopting it instead of appending the styles in a `<style>` element. This allows the styles to be applied without violating CSPs which forbid inline styles.